### PR TITLE
Incoming vROps, outgoing HipChat, multiple token/team support for existing, Slack overhaul

### DIFF
--- a/loginsightwebhookdemo/hipchat.py
+++ b/loginsightwebhookdemo/hipchat.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+"""
+HipChat API makes it difficult to get feature parity with Slack shim.
+Opted for a single message and leveraged the HTML driven activity option.
+This may need to be revisited in the future.
+"""
+
+from loginsightwebhookdemo import app, parse, sendevent
+from flask import request, json
+import logging
+
+
+__author__ = "Steve Flanders"
+__license__ = "Apache v2"
+__email__ = "li-cord@vmware.com"
+__version__ = "1.0"
+
+
+# HipChat incoming webhook URL. For more information see https://www.hipchat.com/docs/apiv2/method/send_room_notification
+HIPCHATURL = ''
+
+
+#@app.route("/endpoint/hipchat/<int:NUMRESULTS>", methods=['POST'])
+#@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>/<int:NUMRESULTS>", methods=['POST'])
+#@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/hipchat", methods=['POST'])
+@app.route("/endpoint/hipchat/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/hipchat/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>", methods=['POST'])
+@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>/<ALERTID>", methods=['PUT'])
+def hipchat(NUMRESULTS=1, ALERTID=None, TEAM=None, ROOMNUM=None, AUTHTOKEN=None):
+    """
+    Consume messages, and send them to HipChat as an Attachment object.
+    If `TEAM/ROOMNUM/AUTHOKEN` is not passed, requires `HIPCHATURL` defined in the form `https://TEAM.hipchat.com/v2/room/0000000/notification?auth_token=XXXXXXXXXXXXXXXXXXXXXXXXXXX`
+    For more information, see https://www.hipchat.com/docs/apiv2/method/send_room_notification
+    """
+    if (AUTHTOKEN is not None):
+        HIPCHATURL = 'https://' + TEAM + '.hipchat.com/v2/room/' + ROOMNUM + '/notification?auth_token=' + AUTHTOKEN
+    if not HIPCHATURL:
+        return ("HIPCHATURL parameter must be set, please edit the shim!", 500, None)
+
+    a = parse(request)
+
+    hipchat_attachments = []
+    attachment_prefix = {
+        "style": "application",
+        "format": "medium",
+        "id": "1",
+    }
+    try:
+        attachment = {
+            "icon": { "url": a['icon'] },
+        }
+        # Log Insight
+        if ('Messages' in a):
+            for message in a['Messages'][:NUMRESULTS]:
+                attachment.update(attachment_prefix)
+                attachment.update({
+                    "title": a['AlertName'],
+                })
+                if (a['url'] != ""):
+                    attachment.update({
+                        "url": a['url'],
+                        "activity": {
+                            "html": a['moreinfo'],
+                        }
+                    })
+                elif (message['text'] is not None):
+                    attachment.update({
+                        "activity": {
+                            "html": message['text'],
+                        }
+                    })
+                if (message['fields'] is not None):
+                    message['fields'] = message['fields'] + a['fields']
+                    attachment.update({
+                        "attributes": [{  # start of dict comprehension
+                            "label": f['name'],
+                            "value": { "label": f['content'] }
+                        } for f in message['fields'] if not f['name'].startswith('__')],
+                    })
+                hipchat_attachments.append(attachment)
+                attachment = {} # only attach the icon to the first card
+        # Additional information (non-product specific)
+        elif (a['fields'] is not None):
+            attachment.update(attachment_prefix)
+            attachment.update({
+                "title": a['AlertName'],
+                "activity": {
+                    "html": a['moreinfo'],
+                },
+                "attributes": [{  # start of dict comprehension
+                    "label": f['name'],
+                    "value": { "label": f['content'] }
+                } for f in a['fields']],
+            })
+            hipchat_attachments.append(attachment)
+    except:
+        logging.exception("Can't create new payload. Check code and try again.")
+        raise
+    if not hipchat_attachments: # If a test alert
+        attachment.update(attachment_prefix)
+        attachment.update({
+            "title": "This is a test webhook alert",
+            "attributes": [
+                {  # start of dict comprehension
+                    "label": "Test",
+                    "value": { "label": "It works!" }
+                }
+            ],
+            "icon": { "url": "http://blogs.vmware.com/management/files/2015/04/li-logo.png" },
+        })
+        hipchat_attachments.append(attachment)
+
+    payload = {
+        "from": a['hookName'],
+        "color": a['color'] if ('color' in a and a['color'] is not None) else "gray",
+        "message_format": "text",
+        "message": a['moreinfo'],
+        "notify": 'true',
+        "card": hipchat_attachments.pop(0),
+    }
+    return sendevent(HIPCHATURL, json.dumps(payload))

--- a/loginsightwebhookdemo/pagerduty.py
+++ b/loginsightwebhookdemo/pagerduty.py
@@ -7,6 +7,7 @@ import logging
 
 __author__ = "Steve Flanders"
 __license__ = "Apache v2"
+__version__ = "1.1"
 
 
 # PagerDuty post url defined by https://v2.developer.pagerduty.com/v2/docs/trigger-events - don't change
@@ -14,7 +15,8 @@ PAGERDUTYURL = 'https://events.pagerduty.com/generic/2010-04-15/create_event.jso
 
 
 @app.route("/endpoint/pagerduty/<SERVICEKEY>", methods=['POST'])
-def pagerduty(SERVICEKEY=None):
+@app.route("/endpoint/pagerduty/<SERVICEKEY>/<ALERTID>", methods=['PUT'])
+def pagerduty(SERVICEKEY=None, ALERTID=None):
     """
     Create a new incident for the Pagerduty service identified by `SERVICEKEY` in the URL.
     Uses the https://v2.developer.pagerduty.com/v2/docs/trigger-events API directly.

--- a/loginsightwebhookdemo/pushbullet.py
+++ b/loginsightwebhookdemo/pushbullet.py
@@ -7,6 +7,7 @@ import logging
 
 __author__ = "Adith Sudhakar"
 __license__ = "Apache v2"
+__verion__ = "1.1"
 
 
 # Pushbullet URL, probably doesn't need to be changed
@@ -17,13 +18,18 @@ PUSHBULLETTOKEN = ''
 
 
 @app.route("/endpoint/pushbullet", methods=['POST'])
-def pushbullet():
+@app.route("/endpoint/pushbullet/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/pushbullet/<TOKEN>", methods=['POST'])
+@app.route("/endpoint/pushbullet/<TOKEN>/<ALERTID>", methods=['PUT'])
+def pushbullet(ALERTID=None, TOKEN=None):
     """
     Send a `link` notification to all devices on pushbullet with a link back to the alert's query.
-    Requires `PUSHBULLETTOKEN` defined, see https://www.pushbullet.com/#settings/account
+    If `TOKEN` is not passed, requires `PUSHBULLETTOKEN` defined, see https://www.pushbullet.com/#settings/account
     """
     if not PUSHBULLETURL:
         return ("PUSHBULLET parameter must be set, please edit the shim!", 500, None)
+    if (TOKEN is not None):
+        PUSHBULLETTOKEN = TOKEN
     if not PUSHBULLETTOKEN:
         return ("PUSHBULLETTOKEN parameter must be set, please edit the shim!", 500, None)
 

--- a/loginsightwebhookdemo/servicenow.py
+++ b/loginsightwebhookdemo/servicenow.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+from loginsightwebhookdemo import app, parse, sendevent
+from flask import request, json
+import logging
+
+
+__author__ = "Steve Flanders"
+__license__ = "Apache v2"
+__verion__ = "1.0"
+
+
+# ServiceNow parameters
+SERVICENOWURL = ''
+SERVICENOWUSER = ''
+SERVICENOWPASS = ''
+
+
+@app.route("/endpoint/servicenow", methods=['POST'])
+@app.route("/endpoint/servicenow/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/servicenow/<TOKEN>", methods=['POST'])
+@app.route("/endpoint/servicenow/<TOKEN>/<ALERTID>", methods=['PUT'])
+def servicenow(ALERTID=None, TOKEN=None):
+    """
+    NOT READY - DO NOT USE!
+    """
+    if not SERVICENOWURL or not SERVICENOWUSER or not SERVICENOWPASS:
+        return ("SERVICENOW* parameters must be set, please edit the shim!", 500, None)
+
+    a = parse(request)
+
+    payload = {
+        "body": a['info'],
+        "title": a['AlertName'],
+        "type": "link",
+        "url": a['url'],
+    }
+    headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
+    return sendevent(SERVICENOWURL, json.dumps(payload), headers, (SERVICENOWUSER, SERVICENOWPASS))

--- a/loginsightwebhookdemo/socialcast.py
+++ b/loginsightwebhookdemo/socialcast.py
@@ -8,7 +8,7 @@ import logging
 __author__ = "Steve Flanders"
 __license__ = "Apache v2"
 __email__ = "li-cord@vmware.com"
-
+__version__ = "1.1"
 
 # Socialcast community Integration URL, defined in the form `https://demo.socialcast.com/api/webhooks/IIIIIIIIII/XXXXXXXXXXX`
 SOCIALCASTURL = ''
@@ -16,13 +16,21 @@ SOCIALCASTURL = ''
 
 @app.route("/endpoint/socialcast", methods=['POST'])
 @app.route("/endpoint/socialcast/<int:NUMRESULTS>", methods=['POST'])
-def socialcast(NUMRESULTS=10):
+@app.route("/endpoint/socialcast/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/socialcast/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>", methods=['POST'])
+@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>/<int:NUMRESULTS>", methods=['POST'])
+@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+def socialcast(ALERTID=None, NUMRESULTS=10, TEAM=None, I=None, X=None):
     """
     Create a post on Socialcast containing log events.
     Limited to `NUMRESULTS` (default 10) or 1MB.
-    Requires `SOCIALCASTURL` defined in the form `https://demo.socialcast.com/api/webhooks/IIIIIIIIII/XXXXXXXXXXX`
+    If `TEAM/I/X` is not passed, requires `SOCIALCASTURL` defined in the form `https://TEAM.socialcast.com/api/webhooks/IIIIIIIIII/XXXXXXXXXXX`
     For more information see https://socialcast.github.io/socialcast/apidoc/incoming_webhook.html
     """
+    if (X is not None):
+        SOCIALCASTURL = 'https://' + TEAM + '.socialcast.com/api/webhooks/' + I + '/' + X
     if not SOCIALCASTURL:
         return ("SOCIALCASTURL parameter must be set, please edit the shim!\n", 500, None)
     # Socialcast cares about the order of the information in the body

--- a/loginsightwebhookdemo/template.py
+++ b/loginsightwebhookdemo/template.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+"""
+Hello! This template is available to help get you started with creating a shim.
+
+Start by adjusting the `TEMPLATE` and `template` parameters.
+Next, adjust the payload based on the API specification of your webhook destination.
+Finally, add an import statement to __init__.py like:
+
+import loginsightwebhookdemo.template
+"""
+
+
+from loginsightwebhookdemo import app, parse, sendevent
+from flask import request, json
+import logging
+
+
+__author__ = ""
+__license__ = "Apache v2"
+__verion__ = "1.0"
+
+
+# Parameters
+TEMPLATEURL = ''
+# Basic auth
+#TEMPLATEUSER = ''
+#TEMPLATEPASS = ''
+
+
+# Route without <ALERTID> are for LI, with are for vROps
+@app.route("/endpoint/template", methods=['POST'])
+@app.route("/endpoint/template/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/template/<TOKEN>", methods=['POST'])
+@app.route("/endpoint/template/<TOKEN>/<ALERTID>", methods=['PUT'])
+def template(ALERTID=None, TOKEN=None):
+    """
+    Information about this shim.
+    """
+    if not TEMPLATEURL or not TEMPLATEUSER or not TEMPLATEPASS:
+        return ("TEMPLATE* parameters must be set, please edit the shim!", 500, None)
+
+    a = parse(request)
+
+    payload = {
+        "body": a['info'],
+        "title": a['AlertName'],
+        "type": "link",
+        "url": a['url'],
+    }
+
+    # Defaults to Content-type: application/json
+    # If changed you must specify the content-type manually
+    #headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
+
+    return sendevent(TEMPLATEURL, json.dumps(payload), headers
+    #return sendevent(TEMPLATEURL, json.dumps(payload), headers, (TEMPLATEUSER, TEMPLATEPASS))

--- a/loginsightwebhookdemo/vrealizeorchestrator.py
+++ b/loginsightwebhookdemo/vrealizeorchestrator.py
@@ -7,6 +7,7 @@ import re
 
 __author__ = "John Dias"
 __license__ = "Apache v2"
+__version__ = "1.1"
 
 
 # vRealize Orchestrator server workflow hostname (or hostname:port)
@@ -15,7 +16,8 @@ VROHOSTNAME = ''
 
 
 @app.route("/endpoint/vro/<WORKFLOWID>", methods=['POST'])
-def vro(WORKFLOWID=None):
+@app.route("/endpoint/vro/<WORKFLOWID>/<ALERTID>", methods=['PUT'])
+def vro(WORKFLOWID=None, ALERTID=None):
     """
     Start a vRealize Orchestrator workflow, passing the entire JSON alert as a base64-encoded string.
     The `WORKFLOWID` is passed in the webhook URL.
@@ -61,7 +63,7 @@ def vro(WORKFLOWID=None):
                 "type": "number",
                 "name": "hitCount",
                 "scope": "local"
-            }            
+            }
         ]
     }
     return sendevent("https://" + VROHOSTNAME + "/vco/api/workflows/" + WORKFLOWID + "/executions", json.dumps(payload))

--- a/runserver.py
+++ b/runserver.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
 """
-This is a demo shim that accepts alert webhooks from VMware vRealize Log Insight 3.3 or newer, implemented using Flask.
+This is a demo shim that accepts incoming webhooks, implemented using Flask.
 
-Run this directly on your development machine or under any WSGI webserver, within the Log Insight virtual appliance.
-The following functions parse the Alert webhook payload from Log Insight, translate and send it to other services.
+Run this directly on your development machine or under any WSGI webserver.
+The following functions parse the webhook payload, translate and send it to other services.
 """
 
 from loginsightwebhookdemo import app
@@ -12,10 +12,12 @@ import logging
 import sys
 
 
-if __name__ == "__main__":
-    # Configure logging
+# Define if you want to leverage SSL
+SSLCERT = ''
+SSLKEY = ''
 
-    # file - overwrite on every start
+def main(PORT):
+    # Configure logging - overwrite on every start
     logging.basicConfig(filename='li_webhook_shim.log', filemode='w', level=logging.DEBUG, format='%(asctime)s %(levelname)s %(message)s')
 
     # stdout
@@ -28,4 +30,14 @@ if __name__ == "__main__":
 
     logging.info("Please navigate to the below URL for the available routes")
 
-    app.run(host='0.0.0.0', port=5001)
+    if (SSLCERT and SSLKEY):
+        context = (SSLCERT, SSLKEY)
+        app.run(host='0.0.0.0', port=PORT, ssl_context=context, threaded=True, debug=True)
+    else:
+        app.run(host='0.0.0.0', port=PORT)
+
+if __name__ == "__main__":
+    PORT = 5001
+    if (len(sys.argv) == 2):
+        PORT = sys.argv[1]
+    main(PORT)


### PR DESCRIPTION
* Refactored parse to make it easier to add incoming webhook formats
* Added support for incoming vRealize Operations Manager REST plugin
* Added incoming TLS support
* Added ability to specify port when invoking runserver
* Added basic auth support to sendevent
* Added support for HipChat including multiple teams/rooms and LI test alerts
* Began to add support for ServiceNow
* Changed Slack webhook format to better match email alerts
* Added support for multiple teams/rooms with Slack
* Added support for LI test alerts with Slack
* Added support for multiple tokens with pushbullet
* Added support for multiple teams/groups with Socialcast