### PR TITLE
Added tests for hipchat + some minor enhancements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ If an issue is discovered with a commit that was not uncovered by tests then the
 
 The output of a LI webhook depends on the type of webhook (i.e. user or system) and type of query (user only). Let's see an example for each:
 
-### System
+### System Notification
 
 ```json
 {
@@ -76,7 +76,7 @@ The output of a LI webhook depends on the type of webhook (i.e. user or system) 
 }
 ```
 
-### User Message Query
+### User Alert: Message Query
 
 ```json
 {
@@ -123,7 +123,7 @@ The output of a LI webhook depends on the type of webhook (i.e. user or system) 
 }
 ```
 
-### User Aggregation Query
+### User Alert: Aggregation Query
 
 ```json
 {
@@ -150,7 +150,7 @@ The output of a LI webhook depends on the type of webhook (i.e. user or system) 
 }
 ```
 
-### User Test Query
+### User Alert: Test Query
 
 ```json
 {

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://api.travis-ci.org/vmware/loginsightwebhookdemo.svg?branch=master
-    :target: https://travis-ci.org/vmware/loginsightwebhookdemo
+.. image:: https://api.travis-ci.org/vmw-loginsight/loginsightwebhookdemo.svg?branch=master
+    :target: https://travis-ci.org/vmw-loginsight/loginsightwebhookdemo
     :alt: Build Status
 
 .. image:: https://coveralls.io/repos/github/vmw-loginsight/webhook-shims/badge.svg?branch=master

--- a/loginsightwebhookdemo/__init__.py
+++ b/loginsightwebhookdemo/__init__.py
@@ -136,11 +136,11 @@ def parsevROps(payload, alert):
         "status": payload['status']             if ('status' in payload) else "",
         "type": payload['type']                 if ('type' in payload) else "",
         "subType": payload['subType']           if ('subType' in payload) else "",
-        "Risk": payload['Risk']                 if ('Risk' in payload) else "",
-        "Efficiency": payload['Efficiency']     if ('Efficiency' in payload) else "",
-        "Health": payload['Health']             if ('Health' in payload) else "",
+        "Risk": payload['Risk']                 if ('Risk' in payload) else "<None>",
+        "Efficiency": payload['Efficiency']     if ('Efficiency' in payload) else "<None>",
+        "Health": payload['Health']             if ('Health' in payload) else "<None>",
         "resourceName": payload['resourceName'] if ('resourceName' in payload) else "",
-        "adapterKind": payload['adapterKind']   if ('adapterKind' in payload) else "",
+        "adapterKind": payload['adapterKind']   if ('adapterKind' in payload) else ">",
         "icon": "http://blogs.vmware.com/management/files/2016/09/vrops-256.png",
     })
     if (alert['status'] == "ACTIVE"):

--- a/loginsightwebhookdemo/slack.py
+++ b/loginsightwebhookdemo/slack.py
@@ -32,12 +32,12 @@ def slack_fields(color, message):
 
 
 @app.route("/endpoint/slack", methods=['POST'])
-@app.route("/endpoint/slack/<int:NUMRESULTS>", methods=['POST'])
 @app.route("/endpoint/slack/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/slack/<int:NUMRESULTS>", methods=['POST'])
 @app.route("/endpoint/slack/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
 @app.route("/endpoint/slack/<T>/<B>/<X>", methods=['POST'])
-@app.route("/endpoint/slack/<T>/<B>/<X>/<int:NUMRESULTS>", methods=['POST'])
 @app.route("/endpoint/slack/<T>/<B>/<X>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/slack/<T>/<B>/<X>/<int:NUMRESULTS>", methods=['POST'])
 @app.route("/endpoint/slack/<T>/<B>/<X>/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
 def slack(NUMRESULTS=10, ALERTID=None, T=None, B=None, X=None):
     """
@@ -46,10 +46,11 @@ def slack(NUMRESULTS=10, ALERTID=None, T=None, B=None, X=None):
     If `T/B/X` is not passed, requires `SLACKURL` defined in the form `https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
     For more information, see https://api.slack.com/incoming-webhooks
     """
-    if (X is not None):
+    # Prefer URL parameters to SLACKURL
+    if X is not None:
         URL = 'https://hooks.slack.com/services/' + T + '/' + B + '/' + X
     elif not SLACKURL or not 'https://hooks.slack.com/services' in SLACKURL:
-        return ("SLACKURL parameter must be set, please edit the shim!", 500, None)
+        return ("SLACKURL parameter must be set properly, please edit the shim!", 500, None)
     else:
         URL = SLACKURL
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+
+import json
+
+
+payloadLI_MQ = json.dumps({
+    "AlertType": 1,
+    "AlertName": "Hello World",
+    "SearchPeriod": 300000,
+    "HitCount": 0.0,
+    "HitOperator": 2,
+    "messages": [
+        {
+            "text": "hello world 1",
+            "timestamp": 1451940578545,
+            "fields": [{
+                "name": "Field_1",
+                "content": "Content 1"
+            }, {
+                "name": "Field_2",
+                "content": "Content 2"
+            }]
+        }, {
+            "text": "hello world 2",
+            "timestamp": 1451940561008,
+            "fields": [{
+                "name": "Field_1",
+                "content": "Content 1_2"
+            }, {
+                "name": "Field_2",
+                "content": "Content 2_2"
+            }]
+        }
+    ],
+    "HasMoreResults": False,
+    "Url": "https://10.11.12.13/s/8pgzq6",
+    "EditUrl": "https://10.11.12.13/s/56monr",
+    "Info": "This is an alert for all the Hello World messages",
+    "NumHits": 2
+})
+
+payloadLI_AQ = json.dumps({
+    "AlertType": 2,
+    "AlertName": "Hello World",
+    "SearchPeriod": 300000,
+    "HitCount": 2.0,
+    "HitOperator": 2,
+    "messages": [
+        {
+            "fields": [{
+                "name": "Field_1",
+                "content": "Content 1"
+            }, {
+                "name": "Field_2",
+                "content": "Content 2"
+            }]
+        }, {
+            "fields": [{
+                "name": "Field_1",
+                "content": "Content 1_2"
+            }, {
+                "name": "Field_2",
+                "content": "Content 2_2"
+            }]
+        }
+    ],
+    "HasMoreResults": True,
+    "Url": "https://10.11.12.13/s/8pgzq6",
+    "EditUrl": "https://10.11.12.13/s/56monr",
+    "Info": "This is an alert for all the Hello World messages",
+    "NumHits": 2
+})
+
+payload = payloadLI_AQ
+
+payloadLI_test = json.dumps({
+    "AlertType": 1,
+    "AlertName": "Hello World",
+    "SearchPeriod": 300000,
+    "HitCount": 0.0,
+    "HitOperator": 2,
+    "messages": [],
+    "HasMoreResults": False,
+    "Url": None,
+    "EditUrl": None,
+    "Info": "hello world 1",
+    "Recommendation": None,
+    "NumHits": 0
+})
+
+payloadLI_sys = json.dumps({
+    "AlertName": "Hello World",
+    "messages": [
+        {
+            "text": "hello world 1",
+            "timestamp": 1451940578545,
+            "fields": []
+        }
+    ],
+})
+
+payloadvROps60 = json.dumps({
+    "startDate": 1369757346267,
+    "criticality": "ALERT_CRITICALITY_LEVEL_WARNING",
+    "resourceId": "sample-object-uuid",
+    "alertId": "sample-alert-uuid",
+    "status": "INACTIVE",
+    "subType": "ALERT_SUBTYPE_AVAILABILITY_PROBLEM",
+    "cancelDate": 1369757346267,
+    "resourceKind": "sample-object-type",
+    "attributeKeyID": 5325,
+    "adapterKind": "sample-adapter-type",
+    "type": "ALERT_TYPE_APPLICATION_PROBLEM",
+    "resourceName": "sample-object-name",
+    "updateDate": 1369757346267,
+    "info": "sample-info"
+})
+
+payloadvROps62 = json.dumps({
+    "startDate": 1369757346267,
+    "criticality": "ALERT_CRITICALITY_LEVEL_WARNING",
+    "Risk": 4.0,
+    "resourceId": "sample-object-uuid",
+    "alertId": "sample-alert-uuid",
+    "status": "ACTIVE",
+    "subType": "ALERT_SUBTYPE_AVAILABILITY_PROBLEM",
+    "cancelDate": 1369757346267,
+    "resourceKind": "sample-object-type",
+    "alertName": "Invalid IP Address for connected Leaf Switch",
+    "attributeKeyID": 5325,
+    "Efficiency": 1.0,
+    "adapterKind": "sample-adapter-type",
+    "Health": 1.0,
+    "type": "ALERT_TYPE_APPLICATION_PROBLEM",
+    "resourceName": "sample-object-name",
+    "updateDate": 1369757346267,
+    "info": "sample-info"
+})

--- a/tests/hipchat_test.py
+++ b/tests/hipchat_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+
+import pytest
+
+import loginsightwebhookdemo
+import loginsightwebhookdemo.hipchat
+
+import conftest
+
+
+client = loginsightwebhookdemo.app.test_client()
+
+NUMRESULTS = '1'
+TEAM = 'vmw-loginsight'
+ROOMNUM = '3417213'
+AUTHTOKEN = 'J9SrD5eHjg6VT1OuqByEF7hHcniahj2sEjrIFl1h'
+
+URL = 'https://vmw-loginsight.hipchat.com/v2/room/3417213/notification?auth_token=J9SrD5eHjg6VT1OuqByEF7hHcniahj2sEjrIFl1h'
+
+WRONGTEAM = 'thisisthewrongteam'
+WRONGROOMNUM = '48232348423984383428234'
+WRONGAUTHTOKEN = 'wrongtoken'
+
+
+@pytest.mark.parametrize("url,post,data,expected", [
+    # No URL
+    (None,
+        '/endpoint/hipchat', conftest.payload,
+        '500 INTERNAL SERVER ERROR'),
+    (None,
+        '/endpoint/hipchat/', conftest.payload,
+        '404 NOT FOUND'),
+    (None,
+        '/endpoint/hipchat/' + NUMRESULTS, conftest.payload,
+        '500 INTERNAL SERVER ERROR'),
+    (None,
+        '/endpoint/hipchat/' + TEAM, conftest.payload,
+        '405 METHOD NOT ALLOWED'),
+    (None,
+        '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM, conftest.payload,
+        '404 NOT FOUND'),
+    (None,
+        '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + AUTHTOKEN, conftest.payload,
+        '204 NO CONTENT'),
+    (None,
+        '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + AUTHTOKEN + '/' + NUMRESULTS, conftest.payload,
+        '204 NO CONTENT'),
+    # Wrong URL
+    (None,
+        '/endpoint/hipchat/' + WRONGTEAM + '/' + ROOMNUM + '/' + AUTHTOKEN, conftest.payload,
+        '204 NO CONTENT'),
+    (None,
+        '/endpoint/hipchat/' + TEAM + '/' + WRONGROOMNUM + '/' + AUTHTOKEN, conftest.payload,
+        '404 NOT FOUND'),
+    (None,
+        '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + WRONGAUTHTOKEN, conftest.payload,
+        '401 UNAUTHORIZED'),
+    # All params
+    (URL,
+        '/endpoint/hipchat', conftest.payload,
+        '204 NO CONTENT'),
+    (URL,
+        '/endpoint/hipchat', conftest.payloadvROps60,
+        '204 NO CONTENT'),
+    (URL,
+        '/endpoint/hipchat', conftest.payloadvROps62,
+        '204 NO CONTENT'),
+    (URL,
+        '/endpoint/hipchat', conftest.payloadLI_test,
+        '204 NO CONTENT'),
+    (URL,
+        '/endpoint/hipchat/' + NUMRESULTS, conftest.payload,
+        '204 NO CONTENT'),
+    (URL,
+        '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + AUTHTOKEN, conftest.payload,
+        '204 NO CONTENT'),
+    (URL,
+        '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + AUTHTOKEN + '/' + NUMRESULTS, conftest.payload,
+        '204 NO CONTENT'),
+])
+def test_hipchat(url, post, data, expected):
+    if url is not None:
+        loginsightwebhookdemo.hipchat.HIPCHATURL = url
+    rsp = client.post(post, data=data, content_type="application/json")
+    assert rsp.status == expected

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -1,142 +1,15 @@
+#!/usr/bin/env python
+
+import json
 import requests
 
 import loginsightwebhookdemo
 
+import conftest
+
 
 client = loginsightwebhookdemo.app.test_client()
 # client2 = loginsightwebhookdemo.app.test_client(5002)
-
-payloadLI_MQ = {
-    "AlertType": 1,
-    "AlertName": "Hello World",
-    "SearchPeriod": 300000,
-    "HitCount": 0.0,
-    "HitOperator": 2,
-    "messages": [
-        {
-            "text": "hello world 1",
-            "timestamp": 1451940578545,
-            "fields": [{
-                "name": "Field_1",
-                "content": "Content 1"
-            }, {
-                "name": "Field_2",
-                "content": "Content 2"
-            }]
-        }, {
-            "text": "hello world 2",
-            "timestamp": 1451940561008,
-            "fields": [{
-                "name": "Field_1",
-                "content": "Content 1_2"
-            }, {
-                "name": "Field_2",
-                "content": "Content 2_2"
-            }]
-        }
-    ],
-    "HasMoreResults": False,
-    "Url": "https://10.11.12.13/s/8pgzq6",
-    "EditUrl": "https://10.11.12.13/s/56monr",
-    "Info": "This is an alert for all the Hello World messages",
-    "NumHits": 2
-}
-
-payloadLI_AQ = {
-    "AlertType": 2,
-    "AlertName": "Hello World",
-    "SearchPeriod": 300000,
-    "HitCount": 2.0,
-    "HitOperator": 2,
-    "messages": [
-        {
-            "fields": [{
-                "name": "Field_1",
-                "content": "Content 1"
-            }, {
-                "name": "Field_2",
-                "content": "Content 2"
-            }]
-        }, {
-            "fields": [{
-                "name": "Field_1",
-                "content": "Content 1_2"
-            }, {
-                "name": "Field_2",
-                "content": "Content 2_2"
-            }]
-        }
-    ],
-    "HasMoreResults": False,
-    "Url": "https://10.11.12.13/s/8pgzq6",
-    "EditUrl": "https://10.11.12.13/s/56monr",
-    "Info": "This is an alert for all the Hello World messages",
-    "NumHits": 2
-}
-
-payloadLI_test = {
-    "AlertType": 1,
-    "AlertName": "Hello World",
-    "SearchPeriod": 300000,
-    "HitCount": 0.0,
-    "HitOperator": 2,
-    "messages": [],
-    "HasMoreResults": False,
-    "Url": None,
-    "EditUrl": None,
-    "Info": "hello world 1",
-    "Recommendation": None,
-    "NumHits": 0
-}
-
-payloadLI_sys = {
-    "AlertName": "Hello World",
-    "messages": [
-        {
-            "text": "hello world 1",
-            "timestamp": 1451940578545,
-            "fields": []
-        }
-    ],
-}
-
-payloadvROps60 = {
-    "startDate": 1369757346267,
-    "criticality": "ALERT_CRITICALITY_LEVEL_WARNING",
-    "resourceId": "sample-object-uuid",
-    "alertId": "sample-alert-uuid",
-    "status": "INACTIVE",
-    "subType": "ALERT_SUBTYPE_AVAILABILITY_PROBLEM",
-    "cancelDate": 1369757346267,
-    "resourceKind": "sample-object-type",
-    "attributeKeyID": 5325,
-    "adapterKind": "sample-adapter-type",
-    "type": "ALERT_TYPE_APPLICATION_PROBLEM",
-    "resourceName": "sample-object-name",
-    "updateDate": 1369757346267,
-    "info": "sample-info"
-}
-
-payloadvROps62 = {
-    "startDate": 1369757346267,
-    "criticality": "ALERT_CRITICALITY_LEVEL_WARNING",
-    "Risk": 4.0,
-    "resourceId": "sample-object-uuid",
-    "alertId": "sample-alert-uuid",
-    "status": "ACTIVE",
-    "subType": "ALERT_SUBTYPE_AVAILABILITY_PROBLEM",
-    "cancelDate": 1369757346267,
-    "resourceKind": "sample-object-type",
-    "alertName": "Invalid IP Address for connected Leaf Switch",
-    "attributeKeyID": 5325,
-    "Efficiency": 1.0,
-    "adapterKind": "sample-adapter-type",
-    "Health": 1.0,
-    "type": "ALERT_TYPE_APPLICATION_PROBLEM",
-    "resourceName": "sample-object-name",
-    "updateDate": 1369757346267,
-    "info": "sample-info"
-}
 
 
 def test_parse():
@@ -149,7 +22,7 @@ def test_parse():
 
 
 def test_parse_LI_MQ():
-    alert = loginsightwebhookdemo.parseLI(payloadLI_MQ, {})
+    alert = loginsightwebhookdemo.parseLI(json.loads(conftest.payloadLI_MQ), {})
     assert alert['hookName'] == 'Log Insight'
     assert alert['color'] == 'red'
     assert alert['AlertName'] == 'Hello World'
@@ -166,7 +39,7 @@ You can edit this alert by clicking: https://10.11.12.13/s/56monr'
 
 
 def test_parse_vROps60_test():
-    alert = loginsightwebhookdemo.parsevROps(payloadvROps60, {})
+    alert = loginsightwebhookdemo.parsevROps(json.loads(conftest.payloadvROps60), {})
     assert alert['hookName'] == 'vRealize Operations Manager'
     assert alert['color'] == 'green'
     assert alert['AlertName'] == '<None>'
@@ -175,9 +48,9 @@ def test_parse_vROps60_test():
     assert alert['status'] == 'INACTIVE'
     assert alert['type'] == 'ALERT_TYPE_APPLICATION_PROBLEM'
     assert alert['subType'] == 'ALERT_SUBTYPE_AVAILABILITY_PROBLEM'
-    assert alert['Risk'] == ''
-    assert alert['Efficiency'] == ''
-    assert alert['Health'] == ''
+    assert alert['Risk'] == '<None>'
+    assert alert['Efficiency'] == '<None>'
+    assert alert['Health'] == '<None>'
     assert alert['resourceName'] == 'sample-object-name'
     assert alert['adapterKind'] == 'sample-adapter-type'
     assert alert['icon'] == 'http://blogs.vmware.com/management/files/2016/09/vrops-256.png'
@@ -185,7 +58,7 @@ def test_parse_vROps60_test():
 
 
 def test_parseLI_MQ():
-    alert = loginsightwebhookdemo.parseLI(payloadLI_MQ, {})
+    alert = loginsightwebhookdemo.parseLI(json.loads(conftest.payloadLI_MQ), {})
     assert alert['hookName'] == 'Log Insight'
     assert alert['color'] == 'red'
     assert alert['AlertName'] == 'Hello World'
@@ -202,7 +75,7 @@ You can edit this alert by clicking: https://10.11.12.13/s/56monr'
 
 
 def test_parseLI_AQ():
-    alert = loginsightwebhookdemo.parseLI(payloadLI_AQ, {})
+    alert = loginsightwebhookdemo.parseLI(json.loads(conftest.payloadLI_AQ), {})
     assert alert['hookName'] == 'Log Insight'
     assert alert['color'] == 'red'
     assert alert['AlertName'] == 'Hello World'
@@ -210,7 +83,7 @@ def test_parseLI_AQ():
     # assert alert['Messages'] == '[{"text": "hello world 1","timestamp": 1451940578545,"fields": [{"name": "Field_1","content": "Content 1"}, { "name": "Field_2","content": "Content 2"}]'
     assert alert['url'] == 'https://10.11.12.13/s/8pgzq6'
     assert alert['editurl'] == 'https://10.11.12.13/s/56monr'
-    assert alert['HasMoreResults'] == 'False'
+    assert alert['HasMoreResults'] == 'True'
     assert alert['NumHits'] == '2'
     assert alert['icon'] == 'http://blogs.vmware.com/management/files/2015/04/li-logo.png'
     assert alert['moreinfo'] == 'Hello World\n\nThis is an alert for all the Hello World messages\n\n\
@@ -219,7 +92,7 @@ You can edit this alert by clicking: https://10.11.12.13/s/56monr'
 
 
 def test_parseLI_sys():
-    alert = loginsightwebhookdemo.parseLI(payloadLI_sys, {})
+    alert = loginsightwebhookdemo.parseLI(json.loads(conftest.payloadLI_sys), {})
     assert alert['hookName'] == 'Log Insight'
     assert alert['color'] == 'red'
     assert alert['AlertName'] == 'Hello World'
@@ -234,7 +107,7 @@ def test_parseLI_sys():
 
 
 def test_parseLI_test():
-    alert = loginsightwebhookdemo.parseLI(payloadLI_test, {})
+    alert = loginsightwebhookdemo.parseLI(json.loads(conftest.payloadLI_test), {})
     assert alert['hookName'] == 'Log Insight'
     assert alert['color'] == 'red'
     assert alert['AlertName'] == 'Hello World'
@@ -251,12 +124,12 @@ def test_parseLI_test():
 
 
 def test_parsevROps_LI():
-    alert = loginsightwebhookdemo.parsevROps(payloadLI_sys, {})
+    alert = loginsightwebhookdemo.parsevROps(json.loads(conftest.payloadLI_sys), {})
     assert alert == {}
 
 
 def test_parsevROps60_test():
-    alert = loginsightwebhookdemo.parsevROps(payloadvROps60, {})
+    alert = loginsightwebhookdemo.parsevROps(json.loads(conftest.payloadvROps60), {})
     assert alert['hookName'] == 'vRealize Operations Manager'
     assert alert['color'] == 'green'
     assert alert['AlertName'] == '<None>'
@@ -265,9 +138,9 @@ def test_parsevROps60_test():
     assert alert['status'] == 'INACTIVE'
     assert alert['type'] == 'ALERT_TYPE_APPLICATION_PROBLEM'
     assert alert['subType'] == 'ALERT_SUBTYPE_AVAILABILITY_PROBLEM'
-    assert alert['Risk'] == ''
-    assert alert['Efficiency'] == ''
-    assert alert['Health'] == ''
+    assert alert['Risk'] == '<None>'
+    assert alert['Efficiency'] == '<None>'
+    assert alert['Health'] == '<None>'
     assert alert['resourceName'] == 'sample-object-name'
     assert alert['adapterKind'] == 'sample-adapter-type'
     assert alert['icon'] == 'http://blogs.vmware.com/management/files/2016/09/vrops-256.png'
@@ -275,7 +148,7 @@ def test_parsevROps60_test():
 
 
 def test_parsevROps62_test():
-    alert = loginsightwebhookdemo.parsevROps(payloadvROps62, {})
+    alert = loginsightwebhookdemo.parsevROps(json.loads(conftest.payloadvROps62), {})
     assert alert['hookName'] == 'vRealize Operations Manager'
     assert alert['color'] == 'yellow'
     assert alert['AlertName'] == 'Invalid IP Address for connected Leaf Switch'

--- a/tests/slack_test.py
+++ b/tests/slack_test.py
@@ -1,99 +1,15 @@
 #!/usr/bin/env python
 
 
-import json
+import pytest
 
 import loginsightwebhookdemo
 import loginsightwebhookdemo.slack
 
+import conftest
+
 
 client = loginsightwebhookdemo.app.test_client()
-
-# Cannot add AlertName as must be unique for testing
-payload = json.dumps({
-    "AlertType": 2,
-    "AlertName": "Hello World",
-    "SearchPeriod": 300000,
-    "HitCount": 2.0,
-    "HitOperator": 2,
-    "messages": [
-        {
-            "fields": [{
-                "name": "Field_1",
-                "content": "Content 1"
-            }, {
-                "name": "Field_2",
-                "content": "Content 2"
-            }]
-        }, {
-            "fields": [{
-                "name": "Field_1",
-                "content": "Content 1_2"
-            }, {
-                "name": "Field_2",
-                "content": "Content 2_2"
-            }]
-        }
-    ],
-    "HasMoreResults": False,
-    "Url": "https://10.11.12.13/s/8pgzq6",
-    "EditUrl": "https://10.11.12.13/s/56monr",
-    "Info": "This is an alert for all the Hello World messages",
-    "NumHits": 2
-})
-
-payloadvROps62 = json.dumps({
-    "startDate": 1369757346267,
-    "criticality": "ALERT_CRITICALITY_LEVEL_WARNING",
-    "Risk": 4.0,
-    "resourceId": "sample-object-uuid",
-    "alertId": "sample-alert-uuid",
-    "status": "ACTIVE",
-    "subType": "ALERT_SUBTYPE_AVAILABILITY_PROBLEM",
-    "cancelDate": 1369757346267,
-    "resourceKind": "sample-object-type",
-    "alertName": "Invalid IP Address for connected Leaf Switch",
-    "attributeKeyID": 5325,
-    "Efficiency": 1.0,
-    "adapterKind": "sample-adapter-type",
-    "Health": 1.0,
-    "type": "ALERT_TYPE_APPLICATION_PROBLEM",
-    "resourceName": "sample-object-name",
-    "updateDate": 1369757346267,
-    "info": "sample-info"
-})
-
-payloadvROps60 = json.dumps({
-    "startDate": 1369757346267,
-    "criticality": "ALERT_CRITICALITY_LEVEL_WARNING",
-    "resourceId": "sample-object-uuid",
-    "alertId": "sample-alert-uuid",
-    "status": "ACTIVE",
-    "subType": "ALERT_SUBTYPE_AVAILABILITY_PROBLEM",
-    "cancelDate": 1369757346267,
-    "resourceKind": "sample-object-type",
-    "attributeKeyID": 5325,
-    "adapterKind": "sample-adapter-type",
-    "type": "ALERT_TYPE_APPLICATION_PROBLEM",
-    "resourceName": "sample-object-name",
-    "updateDate": 1369757346267,
-    "info": "sample-info"
-})
-
-payloadLI_test = json.dumps({
-    "AlertType": 1,
-    "AlertName": "Hello World",
-    "SearchPeriod": 300000,
-    "HitCount": 0.0,
-    "HitOperator": 2,
-    "messages": [],
-    "HasMoreResults": False,
-    "Url": None,
-    "EditUrl": None,
-    "Info": "hello world 1",
-    "Recommendation": None,
-    "NumHits": 0
-})
 
 NUMRESULTS = '1'
 T = 'T3BCFGGDU'
@@ -101,41 +17,65 @@ B = 'B3BL90K4N'
 X = 'Q8BojtVn1Pvjg510aCEOKNrd'
 
 
-def test_slack_nourl():
-    rsp = client.post('/endpoint/slack', data=payload, content_type="application/json")
-    assert rsp.status == '500 INTERNAL SERVER ERROR'
-    rsp = client.post('/endpoint/slack/', data=payload, content_type="application/json")
-    assert rsp.status == '404 NOT FOUND'
-    rsp = client.post('/endpoint/slack/' + NUMRESULTS, data=payload, content_type="application/json")
-    assert rsp.status == '500 INTERNAL SERVER ERROR'
-    rsp = client.post('/endpoint/slack/' + T, data=payload, content_type="application/json")
-    assert rsp.status == '405 METHOD NOT ALLOWED'
-    rsp = client.post('/endpoint/slack/' + T + '/' + B, data=payload, content_type="application/json")
-    assert rsp.status == '404 NOT FOUND'
-    rsp = client.post('/endpoint/slack/' + T + '/' + B + '/' + X, data=payload, content_type="application/json")
-    assert rsp.status == '200 OK'
-
-
-def test_slack_nox():
-    loginsightwebhookdemo.slack.SLACKURL = 'https://hooks.slack.com/services/' + T + '/' + B + '/' + X
-
-    rsp = client.post('/endpoint/slack', data=payload, content_type="application/json")
-    assert rsp.status == '200 OK'
-    rsp = client.post('/endpoint/slack', data=payloadvROps60, content_type="application/json")
-    assert rsp.status == '200 OK'
-    rsp = client.post('/endpoint/slack', data=payloadLI_test, content_type="application/json")
-    assert rsp.status == '200 OK'
-    rsp = client.post('/endpoint/slack/' + NUMRESULTS, data=payload, content_type="application/json")
-    assert rsp.status == '200 OK'
-
-
-def test_slack_wrongurl():
-    loginsightwebhookdemo.slack.SLACKURL = 'https://vmw-loginsight.slack.com'
-
-    rsp = client.post('/endpoint/slack', data=payload, content_type="application/json")
-    assert rsp.status == '500 INTERNAL SERVER ERROR'
-
-    loginsightwebhookdemo.slack.SLACKURL = 'https://hooks.slack.com/services/a/b/c'
-
-    rsp = client.post('/endpoint/slack', data=payload, content_type="application/json")
-    assert rsp.status == '404 NOT FOUND'
+@pytest.mark.parametrize("url,post,data,expected", [
+    # No URL
+    (None,
+        '/endpoint/slack',
+        conftest.payload,
+        '500 INTERNAL SERVER ERROR'),
+    (None,
+        '/endpoint/slack/',
+        conftest.payload,
+        '404 NOT FOUND'),
+    (None,
+        '/endpoint/slack/' + NUMRESULTS,
+        conftest.payload,
+        '500 INTERNAL SERVER ERROR'),
+    (None,
+        '/endpoint/slack/' + T,
+        conftest.payload,
+        '405 METHOD NOT ALLOWED'),
+    (None,
+        '/endpoint/slack/' + T + '/' + B,
+        conftest.payload,
+        '404 NOT FOUND'),
+    (None,
+        '/endpoint/slack/' + T + '/' + B + '/' + X,
+        conftest.payload,
+        '200 OK'),
+    (None,
+        '/endpoint/slack/' + T + '/' + B + '/' + X + '/' + NUMRESULTS,
+        conftest.payload,
+        '200 OK'),
+    # All params
+    ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X,
+        '/endpoint/slack',
+        conftest.payload,
+        '200 OK'),
+    ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X,
+        '/endpoint/slack',
+        conftest.payloadvROps60,
+        '200 OK'),
+    ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X,
+        '/endpoint/slack',
+        conftest.payloadLI_test,
+        '200 OK'),
+    ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X,
+        '/endpoint/slack/' + NUMRESULTS,
+        conftest.payload,
+        '200 OK'),
+    # Wrong URL
+    ('https://vmw-loginsight.slack.com',
+        '/endpoint/slack',
+        conftest.payload,
+        '500 INTERNAL SERVER ERROR'),
+    ('https://hooks.slack.com/services/a/b/c',
+        '/endpoint/slack',
+        conftest.payload,
+        '404 NOT FOUND'),
+])
+def test_slack(url, post, data, expected):
+    if url is not None:
+        loginsightwebhookdemo.slack.SLACKURL = url
+    rsp = client.post(post, data=data, content_type="application/json")
+    assert rsp.status == expected


### PR DESCRIPTION
* Added proper support for NUMRESULTS
* Add poor man's validation of URL
* Add icon to all messages types
* Proper check for a test message
* Modified parsevROps to support hipchat API requirements
* Switched to pytest parameterization

Other changes:

* Moved payload parameters from init_tes/slack_test to conftest.py
* Minor changes to slack given changes to payload in test
* Switched slack to pytest parameterization
* Minor changes to CONTRIBUTING.md for clarity
* Fixed Travis CI link in README.rst