### PR TITLE
Fix support for vROps in PD shim

### DIFF
--- a/loginsightwebhookdemo/__init__.py
+++ b/loginsightwebhookdemo/__init__.py
@@ -11,6 +11,7 @@ This is a demo shim, implemented using Flask, that accepts alert webhooks from:
 
 You can invoke `runserver.py [<port>]` directly on your development machine or run the Flask app under any WSGI webserver.
 Don't run it on the Log Insight or vRealize Operations Manager virtual appliance, though.
+Some shims require manually setting variables within the shim, while others work via URLs. Only modify variables BEFORE the app.route section in each shim.
 
 As a demonstration, these shims are optimized for readability.
 There is minimal error handling and no attempt to retransmit.
@@ -142,6 +143,9 @@ def parsevROps(payload, alert):
         "resourceName": payload['resourceName'] if ('resourceName' in payload) else "",
         "adapterKind": payload['adapterKind']   if ('adapterKind' in payload) else ">",
         "icon": "http://blogs.vmware.com/management/files/2016/09/vrops-256.png",
+        "Messages":"",
+        "url":"",
+        "editurl":"",
     })
     if (alert['status'] == "ACTIVE"):
         if (alert['criticality'] == "ALERT_CRITICALITY_LEVEL_CRITICAL" or

--- a/loginsightwebhookdemo/pagerduty.py
+++ b/loginsightwebhookdemo/pagerduty.py
@@ -13,7 +13,7 @@ __version__ = "1.1"
 # PagerDuty post url defined by https://v2.developer.pagerduty.com/v2/docs/trigger-events - don't change
 PAGERDUTYURL = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
 
-
+# DO NOT MODIFY ANYTHING BELOW HERE!!!
 @app.route("/endpoint/pagerduty/<SERVICEKEY>", methods=['POST'])
 @app.route("/endpoint/pagerduty/<SERVICEKEY>/<ALERTID>", methods=['PUT'])
 def pagerduty(SERVICEKEY=None, ALERTID=None):

--- a/tests/pagerduty_test.py
+++ b/tests/pagerduty_test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+
+import pytest
+
+import loginsightwebhookdemo.pagerduty
+
+import conftest
+
+
+APIKEY = 'abc123'
+
+
+@pytest.mark.parametrize("post,data,expected", [
+    ('/endpoint/pagerduty/', conftest.payload, '404 NOT FOUND'),
+    ('/endpoint/pagerduty/' + APIKEY, conftest.payload, '500 INTERNAL SERVER ERROR'),
+])
+def test_pgaerduty_nourl(post, data, expected):
+    loginsightwebhookdemo.pagerduty.PAGERDUTYURL = ''
+
+    rsp = conftest.client.post(post, data=data, content_type="application/json")
+    assert rsp.status == expected
+
+
+@pytest.mark.parametrize("post,data,expected", [
+    ('/endpoint/pagerduty/' + APIKEY, conftest.payload, '400 BAD REQUEST'),
+    ('/endpoint/pagerduty/' + APIKEY, conftest.payloadvROps60, '400 BAD REQUEST'),
+    ('/endpoint/pagerduty/' + APIKEY, conftest.payloadLI_test, '400 BAD REQUEST'),
+])
+def test_pgaerduty_allparams(post, data, expected):
+    loginsightwebhookdemo.pagerduty.PAGERDUTYURL = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
+
+    rsp = conftest.client.post(post, data=data, content_type="application/json")
+    assert rsp.status == expected
+
+
+# Will not work by default since PD does not offer a free account for testing API
+# Change APIKEY2 to something valid if you want to test
+# APIKEY2 = 'df5369ca51b241cfbe8aeb91d656b3e4'
+# @pytest.mark.parametrize("post,data,expected", [
+#     ('/endpoint/pagerduty/' + APIKEY2, conftest.payload, '200 OK'),
+#     ('/endpoint/pagerduty/' + APIKEY2, conftest.payloadvROps60, '200 OK'),
+#     ('/endpoint/pagerduty/' + APIKEY2, conftest.payloadLI_test, '200 OK'),
+# ])
+# def test_pgaerduty_allparams_real(post, data, expected):
+#     loginsightwebhookdemo.pagerduty.PAGERDUTYURL = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
+#
+#     rsp = conftest.client.post(post, data=data, content_type="application/json")
+#     assert rsp.status == expected


### PR DESCRIPTION
Some required fields were missing during vROps parsing which impacted at
least the PD shim. Added the missing fields. Also refactored PD tests
and added commented tests that can be used against a valid API key.

Updated the help page.