### PR TITLE
Support POST and PUT methods for vROps payloads.

### DIFF
--- a/loginsightwebhookdemo/bugzilla.py
+++ b/loginsightwebhookdemo/bugzilla.py
@@ -27,29 +27,27 @@ VERIFY = True
 
 # Route without <ALERTID> are for LI, with are for vROps
 @app.route("/endpoint/bugzilla", methods=['POST'])
-@app.route("/endpoint/bugzilla/<ALERTID>", methods=['PUT'])
 @app.route("/endpoint/bugzilla/<TOKEN>", methods=['POST'])
-@app.route("/endpoint/bugzilla/<TOKEN>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/bugzilla/<TOKEN>/<ALERTID>", methods=['POST','PUT'])
 @app.route("/endpoint/bugzilla/<TOKEN>/<PRODUCT>/<COMPONENT>/<VERSION>", methods=['POST'])
-@app.route("/endpoint/bugzilla/<TOKEN>/<PRODUCT>/<COMPONENT>/<VERSION>/<ALERTID>", methods=['PUT'])
-@app.route("/endpoint/bugzilla/<PRODUCT>/<COMPONENT>/<VERSION>", methods=['POST'])
-@app.route("/endpoint/bugzilla/<PRODUCT>/<COMPONENT>/<VERSION>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/bugzilla/<TOKEN>/<PRODUCT>/<COMPONENT>/<VERSION>/<ALERTID>", methods=['POST','PUT'])
 def bugzilla(ALERTID=None, TOKEN=None, PRODUCT=None, COMPONENT=None, VERSION=None):
     """
     Create a new bug for every incoming webhook that does not already have an open bug.
     If an bug is already open, add a new comment to the open bug.
     Uniqueness is determined by the incoming webhook alert name combined with bugzilla product and component.
     Requires BUGZILLA* parameters to be defined.
+    You can pass an authentication token in the URL. For basic auth, pass `-` as the token.
     """
     if (not BUGZILLAURL or
-        ((not BUGZILLAUSER or not BUGZILLAPASS) and not TOKEN) or
+        ((not BUGZILLAUSER or not BUGZILLAPASS) and (not TOKEN or TOKEN == '-')) or
         ((not BUGZILLAPRODUCT or not BUGZILLACOMPONENT or not BUGZILLAVERSION) and not VERSION)):
             logging.debug("URL: %s\nUSER: %s\nPASS: %s\nTOKEN: %s\nPRODUCT: %s / %s\nCOMPONENT: %s / %s\nVERSION: %s / %s" % (BUGZILLAURL, BUGZILLAUSER, BUGZILLAPASS, TOKEN, BUGZILLAPRODUCT, PRODUCT, BUGZILLACOMPONENT, COMPONENT, BUGZILLAVERSION, VERSION))
             return ("BUGZILLA* parameters must be set, please edit the shim!", 500, None)
 
     a = parse(request)
 
-    if TOKEN:
+    if TOKEN and TOKEN != '-':
         auth = 'api_key=' + TOKEN
     else:
         auth = 'login=' + BUGZILLAUSER + '&password=' + BUGZILLAPASS

--- a/loginsightwebhookdemo/hipchat.py
+++ b/loginsightwebhookdemo/hipchat.py
@@ -22,13 +22,11 @@ HIPCHATURL = ''
 
 
 @app.route("/endpoint/hipchat", methods=['POST'])
-@app.route("/endpoint/hipchat/<ALERTID>", methods=['PUT'])
-@app.route("/endpoint/hipchat/<int:NUMRESULTS>", methods=['POST'])
-@app.route("/endpoint/hipchat/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/hipchat/<ALERTID>", methods=['POST','PUT'])
+@app.route("/endpoint/hipchat/<ALERTID>/<int:NUMRESULTS>", methods=['POST','PUT'])
 @app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>", methods=['POST'])
-@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>/<ALERTID>", methods=['PUT'])
-@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>/<int:NUMRESULTS>", methods=['POST'])
-@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>/<ALERTID>", methods=['POST','PUT'])
+@app.route("/endpoint/hipchat/<TEAM>/<ROOMNUM>/<AUTHTOKEN>/<ALERTID>/<int:NUMRESULTS>", methods=['POST','PUT'])
 def hipchat(NUMRESULTS=1, ALERTID=None, TEAM=None, ROOMNUM=None, AUTHTOKEN=None):
     """
     Consume messages, and send them to HipChat as an Attachment object.

--- a/loginsightwebhookdemo/jenkins.py
+++ b/loginsightwebhookdemo/jenkins.py
@@ -19,9 +19,9 @@ JENKINSTOKEN = ''
 
 # Route without <ALERTID> are for LI, with are for vROps
 @app.route("/endpoint/jenkins", methods=['POST'])
-@app.route("/endpoint/jenkins/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/jenkins/<ALERTID>", methods=['POST','PUT'])
 @app.route("/endpoint/jenkins/<JOBNAME>/<TOKEN>", methods=['POST'])
-@app.route("/endpoint/jenkins/<JOBNAME>/<TOKEN>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/jenkins/<JOBNAME>/<TOKEN>/<ALERTID>", methods=['POST','PUT'])
 def jenkins(ALERTID=None, JOBNAME=None, TOKEN=None):
     """
     If called, run a Jenkins job without parameters -- request results are discarded.

--- a/loginsightwebhookdemo/opsgenie.py
+++ b/loginsightwebhookdemo/opsgenie.py
@@ -15,9 +15,9 @@ OPSGENIEURL = 'https://api.opsgenie.com/v1/json/alert'
 
 
 @app.route("/endpoint/opsgenie/<APIKEY>", methods=['POST'])
-@app.route("/endpoint/opsgenie/<APIKEY>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/opsgenie/<APIKEY>/<ALERTID>", methods=['POST','PUT'])
 @app.route("/endpoint/opsgenie/<APIKEY>/<TEAM>", methods=['POST'])
-@app.route("/endpoint/opsgenie/<APIKEY>/<TEAM>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/opsgenie/<APIKEY>/<TEAM>/<ALERTID>", methods=['POST','PUT'])
 def opsgenie(APIKEY=None, TEAM=None, ALERTID=None):
     """
     Create a new incident for the opsgenie service identified by `APIKEY` in the URL.

--- a/loginsightwebhookdemo/pagerduty.py
+++ b/loginsightwebhookdemo/pagerduty.py
@@ -15,7 +15,7 @@ PAGERDUTYURL = 'https://events.pagerduty.com/generic/2010-04-15/create_event.jso
 
 # DO NOT MODIFY ANYTHING BELOW HERE!!!
 @app.route("/endpoint/pagerduty/<SERVICEKEY>", methods=['POST'])
-@app.route("/endpoint/pagerduty/<SERVICEKEY>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/pagerduty/<SERVICEKEY>/<ALERTID>", methods=['POST','PUT'])
 def pagerduty(SERVICEKEY=None, ALERTID=None):
     """
     Create a new incident for the Pagerduty service identified by `SERVICEKEY` in the URL.

--- a/loginsightwebhookdemo/pushbullet.py
+++ b/loginsightwebhookdemo/pushbullet.py
@@ -18,9 +18,9 @@ PUSHBULLETTOKEN = ''
 
 
 @app.route("/endpoint/pushbullet", methods=['POST'])
-@app.route("/endpoint/pushbullet/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/pushbullet/<ALERTID>", methods=['POST','PUT'])
 @app.route("/endpoint/pushbullet/<TOKEN>", methods=['POST'])
-@app.route("/endpoint/pushbullet/<TOKEN>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/pushbullet/<TOKEN>/<ALERTID>", methods=['POST','PUT'])
 def pushbullet(ALERTID=None, TOKEN=None):
     """
     Send a `link` notification to all devices on pushbullet with a link back to the alert's query.

--- a/loginsightwebhookdemo/servicenow.py
+++ b/loginsightwebhookdemo/servicenow.py
@@ -17,7 +17,7 @@ SERVICENOWPASS = ''
 
 
 @app.route("/endpoint/servicenow", methods=['POST'])
-@app.route("/endpoint/servicenow/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/servicenow/<ALERTID>", methods=['POST','PUT'])
 def servicenow(ALERTID=None):
     """
     Create a new incident for every incoming webhook that does not already have an active incident.

--- a/loginsightwebhookdemo/slack.py
+++ b/loginsightwebhookdemo/slack.py
@@ -32,13 +32,11 @@ def slack_fields(color, message):
 
 
 @app.route("/endpoint/slack", methods=['POST'])
-@app.route("/endpoint/slack/<ALERTID>", methods=['PUT'])
-@app.route("/endpoint/slack/<int:NUMRESULTS>", methods=['POST'])
-@app.route("/endpoint/slack/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/slack/<ALERTID>", methods=['POST','PUT'])
+@app.route("/endpoint/slack/<ALERTID>/<int:NUMRESULTS>", methods=['POST','PUT'])
 @app.route("/endpoint/slack/<T>/<B>/<X>", methods=['POST'])
-@app.route("/endpoint/slack/<T>/<B>/<X>/<ALERTID>", methods=['PUT'])
-@app.route("/endpoint/slack/<T>/<B>/<X>/<int:NUMRESULTS>", methods=['POST'])
-@app.route("/endpoint/slack/<T>/<B>/<X>/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/slack/<T>/<B>/<X>/<ALERTID>", methods=['POST','PUT'])
+@app.route("/endpoint/slack/<T>/<B>/<X>/<ALERTID>/<int:NUMRESULTS>", methods=['POST','PUT'])
 def slack(NUMRESULTS=10, ALERTID=None, T=None, B=None, X=None):
     """
     Consume messages, and send them to Slack as an Attachment object.

--- a/loginsightwebhookdemo/socialcast.py
+++ b/loginsightwebhookdemo/socialcast.py
@@ -15,13 +15,11 @@ SOCIALCASTURL = ''
 
 
 @app.route("/endpoint/socialcast", methods=['POST'])
-@app.route("/endpoint/socialcast/<int:NUMRESULTS>", methods=['POST'])
-@app.route("/endpoint/socialcast/<ALERTID>", methods=['PUT'])
-@app.route("/endpoint/socialcast/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/socialcast/<ALERTID>", methods=['POST','PUT'])
+@app.route("/endpoint/socialcast/<ALERTID>/<int:NUMRESULTS>", methods=['POST','PUT'])
 @app.route("/endpoint/socialcast/<TEAM>/<I>/<X>", methods=['POST'])
-@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>/<int:NUMRESULTS>", methods=['POST'])
-@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>/<ALERTID>", methods=['PUT'])
-@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>/<int:NUMRESULTS>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>/<ALERTID>", methods=['POST','PUT'])
+@app.route("/endpoint/socialcast/<TEAM>/<I>/<X>/<ALERTID>/<int:NUMRESULTS>", methods=['POST','PUT'])
 def socialcast(ALERTID=None, NUMRESULTS=10, TEAM=None, I=None, X=None):
     """
     Create a post on Socialcast containing log events.

--- a/loginsightwebhookdemo/zendesk.py
+++ b/loginsightwebhookdemo/zendesk.py
@@ -19,8 +19,8 @@ ZENDESKTOKEN = '' # required if ZENDESKPASS is not specifed or TOKEN is not pass
 
 @app.route("/endpoint/zendesk", methods=['POST'])
 @app.route("/endpoint/zendesk/<EMAIL>/<TOKEN>", methods=['POST'])
-@app.route("/endpoint/zendesk/<ALERTID>", methods=['PUT'])
-@app.route("/endpoint/zendesk/<EMAIL>/<TOKEN>/<ALERTID>", methods=['PUT'])
+@app.route("/endpoint/zendesk/<ALERTID>", methods=['POST','PUT'])
+@app.route("/endpoint/zendesk/<EMAIL>/<TOKEN>/<ALERTID>", methods=['POST','PUT'])
 def zendesk(ALERTID=None, EMAIL=None, TOKEN=None):
     """
     Create a new incident for every incoming webhook that does not already have an open incident.

--- a/tests/bugzilla_test.py
+++ b/tests/bugzilla_test.py
@@ -53,16 +53,10 @@ def test_bugzilla_noparams():
     rsp = client.post('/endpoint/bugzilla/' + TOKEN, data=payload, content_type="application/json")
     assert rsp.status == '500 INTERNAL SERVER ERROR'
     rsp = client.post('/endpoint/bugzilla/' + TOKEN + '/' + PRODUCT, data=payload, content_type="application/json")
-    assert rsp.status == '405 METHOD NOT ALLOWED'
+    assert rsp.status == '500 INTERNAL SERVER ERROR'
     rsp = client.post('/endpoint/bugzilla/' + TOKEN + '/' + PRODUCT + '/' + COMPONENT, data=payload, content_type="application/json")
-    assert rsp.status == '500 INTERNAL SERVER ERROR'
+    assert rsp.status == '404 NOT FOUND'
     rsp = client.post('/endpoint/bugzilla/' + TOKEN + '/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
-    assert rsp.status == '500 INTERNAL SERVER ERROR'
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT, data=payload, content_type="application/json")
-    assert rsp.status == '500 INTERNAL SERVER ERROR'
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT + '/' + COMPONENT, data=payload, content_type="application/json")
-    assert rsp.status == '405 METHOD NOT ALLOWED'
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
     assert rsp.status == '500 INTERNAL SERVER ERROR'
 
 
@@ -86,7 +80,7 @@ def test_bugzilla_wrongpass():
 
     payload = generate_alertname()
 
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
+    rsp = client.post('/endpoint/bugzilla/-/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
     assert rsp.status == '401 UNAUTHORIZED'
 
 
@@ -98,7 +92,7 @@ def test_bugzilla_nopass():
     assert rsp.status == '200 OK'
     rsp = client.post('/endpoint/bugzilla', data=payload, content_type="application/json")
     assert rsp.status == '500 INTERNAL SERVER ERROR'
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
+    rsp = client.post('/endpoint/bugzilla/-/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
     assert rsp.status == '500 INTERNAL SERVER ERROR'
 
 
@@ -115,7 +109,7 @@ def test_bugzilla_wrongtoken():
 def test_bugzilla_allparams_allurl():
     payload = generate_alertname()
 
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
+    rsp = client.post('/endpoint/bugzilla/-/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
     # This does not confirm that VERSION is used instead of loginsightwebhookdemo.bugzilla.VERSION
     # Handled in test_bugzilla_e2e
     assert rsp.status == '200 OK'
@@ -127,14 +121,6 @@ def test_bugzilla_notoken():
     rsp = client.post('/endpoint/bugzilla', data=payload, content_type="application/json")
     assert rsp.status == '200 OK'
 
-    payload = generate_alertname()
-
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT, data=payload, content_type="application/json")
-    assert rsp.status == '400 BAD REQUEST'
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT + '/' + COMPONENT, data=payload, content_type="application/json")
-    assert rsp.status == '405 METHOD NOT ALLOWED'
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
-    assert rsp.status == '200 OK'
 
 # Generate a payload that can be re-used for the rest of the tests
 payload = generate_alertname()
@@ -149,7 +135,7 @@ def test_bugzilla_noverify():
 
 # Try to post with the same AlertName to ensure that update works as well
 def test_bugzilla_update():
-    rsp = client.post('/endpoint/bugzilla/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
+    rsp = client.post('/endpoint/bugzilla/' + TOKEN + '/' + PRODUCT + '/' + COMPONENT + '/' + VERSION, data=payload, content_type="application/json")
     assert rsp.status == '200 OK'
 
 

--- a/tests/hipchat_test.py
+++ b/tests/hipchat_test.py
@@ -20,64 +20,73 @@ WRONGROOMNUM = '48232348423984383428234'
 WRONGAUTHTOKEN = 'wrongtoken'
 
 
-@pytest.mark.parametrize("url,post,data,expected", [
+@pytest.mark.parametrize("url,post,data,expected,method", [
     # No URL
     (None,
         '/endpoint/hipchat', conftest.payload,
-        '500 INTERNAL SERVER ERROR'),
+        '500 INTERNAL SERVER ERROR', 'POST'),
     (None,
         '/endpoint/hipchat/', conftest.payload,
-        '404 NOT FOUND'),
+        '404 NOT FOUND', 'POST'),
     (None,
         '/endpoint/hipchat/' + NUMRESULTS, conftest.payload,
-        '500 INTERNAL SERVER ERROR'),
+        '500 INTERNAL SERVER ERROR', 'POST'),
     (None,
         '/endpoint/hipchat/' + TEAM, conftest.payload,
-        '405 METHOD NOT ALLOWED'),
+        '500 INTERNAL SERVER ERROR', 'POST'),
     (None,
         '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM, conftest.payload,
-        '404 NOT FOUND'),
+        '500 INTERNAL SERVER ERROR', 'POST'),
     (None,
         '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + AUTHTOKEN, conftest.payload,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
     (None,
         '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + AUTHTOKEN + '/' + NUMRESULTS, conftest.payload,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
     # Wrong URL
     (None,
         '/endpoint/hipchat/' + WRONGTEAM + '/' + ROOMNUM + '/' + AUTHTOKEN, conftest.payload,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
     (None,
         '/endpoint/hipchat/' + TEAM + '/' + WRONGROOMNUM + '/' + AUTHTOKEN, conftest.payload,
-        '404 NOT FOUND'),
+        '404 NOT FOUND', 'POST'),
     (None,
         '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + WRONGAUTHTOKEN, conftest.payload,
-        '401 UNAUTHORIZED'),
+        '401 UNAUTHORIZED', 'POST'),
     # All params
     (URL,
         '/endpoint/hipchat', conftest.payload,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
     (URL,
         '/endpoint/hipchat', conftest.payloadvROps60,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
+    (URL,
+        '/endpoint/hipchat/abc123', conftest.payloadvROps60,
+        '204 NO CONTENT', 'PUT'),
     (URL,
         '/endpoint/hipchat', conftest.payloadvROps62,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
+    (URL,
+        '/endpoint/hipchat/abc123', conftest.payloadvROps62,
+        '204 NO CONTENT', 'PUT'),
     (URL,
         '/endpoint/hipchat', conftest.payloadLI_test,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
     (URL,
         '/endpoint/hipchat/' + NUMRESULTS, conftest.payload,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
     (URL,
         '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + AUTHTOKEN, conftest.payload,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
     (URL,
         '/endpoint/hipchat/' + TEAM + '/' + ROOMNUM + '/' + AUTHTOKEN + '/' + NUMRESULTS, conftest.payload,
-        '204 NO CONTENT'),
+        '204 NO CONTENT', 'POST'),
 ])
-def test_hipchat(url, post, data, expected):
+def test_hipchat(url, post, data, expected, method):
     if url is not None:
         loginsightwebhookdemo.hipchat.HIPCHATURL = url
-    rsp = conftest.client.post(post, data=data, content_type="application/json")
+    if method == 'PUT':
+        rsp = conftest.client.put(post, data=data, content_type="application/json")
+    else:
+        rsp = conftest.client.post(post, data=data, content_type="application/json")
     assert rsp.status == expected

--- a/tests/slack_test.py
+++ b/tests/slack_test.py
@@ -14,65 +14,76 @@ B = 'B3BL90K4N'
 X = 'Q8BojtVn1Pvjg510aCEOKNrd'
 
 
-@pytest.mark.parametrize("url,post,data,expected", [
+@pytest.mark.parametrize("url,post,data,expected,method", [
     # No URL
     (None,
         '/endpoint/slack',
         conftest.payload,
-        '500 INTERNAL SERVER ERROR'),
+        '500 INTERNAL SERVER ERROR', 'POST'),
     (None,
         '/endpoint/slack/',
         conftest.payload,
-        '404 NOT FOUND'),
+        '404 NOT FOUND', 'POST'),
     (None,
-        '/endpoint/slack/' + NUMRESULTS,
+        '/endpoint/slack/alertid/' + NUMRESULTS,
         conftest.payload,
-        '500 INTERNAL SERVER ERROR'),
+        '500 INTERNAL SERVER ERROR', 'PUT'),
     (None,
         '/endpoint/slack/' + T,
         conftest.payload,
-        '405 METHOD NOT ALLOWED'),
+        '500 INTERNAL SERVER ERROR', 'POST'),
     (None,
         '/endpoint/slack/' + T + '/' + B,
         conftest.payload,
-        '404 NOT FOUND'),
+        '404 NOT FOUND', 'POST'),
     (None,
         '/endpoint/slack/' + T + '/' + B + '/' + X,
         conftest.payload,
-        '200 OK'),
+        '200 OK', 'POST'),
     (None,
-        '/endpoint/slack/' + T + '/' + B + '/' + X + '/' + NUMRESULTS,
-        conftest.payload,
-        '200 OK'),
+        '/endpoint/slack/' + T + '/' + B + '/' + X + '/alertid',
+        conftest.payloadvROps60,
+        '200 OK', 'PUT'),
+    (None,
+        '/endpoint/slack/' + T + '/' + B + '/' + X + '/alertid' + NUMRESULTS,
+        conftest.payloadvROps62,
+        '200 OK', 'PUT'),
     # All params
     ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X,
         '/endpoint/slack',
         conftest.payload,
-        '200 OK'),
-    ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X,
+        '200 OK', 'POST'),
+    ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X + '/alertid',
         '/endpoint/slack',
         conftest.payloadvROps60,
-        '200 OK'),
+        '200 OK', 'POST'),
+    ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X + '/alertid',
+        '/endpoint/slack',
+        conftest.payloadvROps62,
+        '200 OK', 'POST'),
     ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X,
         '/endpoint/slack',
         conftest.payloadLI_test,
-        '200 OK'),
+        '200 OK', 'POST'),
     ('https://hooks.slack.com/services/' + T + '/' + B + '/' + X,
         '/endpoint/slack/' + NUMRESULTS,
         conftest.payload,
-        '200 OK'),
+        '200 OK', 'POST'),
     # Wrong URL
     ('https://vmw-loginsight.slack.com',
         '/endpoint/slack',
         conftest.payload,
-        '500 INTERNAL SERVER ERROR'),
+        '500 INTERNAL SERVER ERROR', 'POST'),
     ('https://hooks.slack.com/services/a/b/c',
         '/endpoint/slack',
         conftest.payload,
-        '404 NOT FOUND'),
+        '404 NOT FOUND', 'POST'),
 ])
-def test_slack(url, post, data, expected):
+def test_slack(url, post, data, expected, method):
     if url is not None:
         loginsightwebhookdemo.slack.SLACKURL = url
-    rsp = conftest.client.post(post, data=data, content_type="application/json")
+    if method == 'PUT':
+        rsp = conftest.client.put(post, data=data, content_type="application/json")
+    else:
+        rsp = conftest.client.post(post, data=data, content_type="application/json")
     assert rsp.status == expected


### PR DESCRIPTION
NOTE: This change impacts the routes of multiple shims -- user changes
may be required after updating.

vROps uses POST for creates and updates to alerts while using PUT for
cancelling. Added support for both methods. In order to support this,
some routes now required an `<ALERTID>` to specify certain options such as
`<NUMRESULTS>`. In the case of bugzilla, a separate endpoint needed to be
added.