### PR TITLE
Fix for issue #34 - catch HTTP 2XX and return HTTP 200

### DIFF
--- a/loginsightwebhookdemo/vrealizeorchestrator.py
+++ b/loginsightwebhookdemo/vrealizeorchestrator.py
@@ -128,4 +128,10 @@ def vro(WORKFLOWID=None, TOKEN=None, HOK=None, ALERTID=None):
                 }
             ]
         }
-    return callapi("https://" + VROHOSTNAME + "/vco/api/workflows/" + WORKFLOWID + "/executions", 'post', json.dumps(payload), HEADERS, AUTH, VERIFY)
+    # Execute the request
+    response = callapi("https://" + VROHOSTNAME + "/vco/api/workflows/" + WORKFLOWID + "/executions", 'post', json.dumps(payload), HEADERS, AUTH, VERIFY)
+    try: # Kludge to get around Log Insight bug (not accepting HTTP 202 as a valid response)
+        if response[1] >= 200 and response[1] < 300:
+            return ("OK", 200, None)
+    except:
+        return response


### PR DESCRIPTION
Fixes issue #34 where Log Insight expects HTTP 200 and retries the webhook if it doesn't receive it.