### PR TITLE
Fix issue #45 - use httpb.in instead of google.com

### DIFF
--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -198,10 +198,10 @@ def test_callapi():
         assert True
     else:
         assert False
-    assert 'method' in loginsightwebhookdemo.callapi('https://httpbin.org/anything', 'get')
-    assert 'authenticated' in loginsightwebhookdemo.callapi('https://httpbin.org/basic-auth/user/passwd', 'get', None, {"Cache-control": "no-cache"}, ('user', 'passwd'), False)
-    print(loginsightwebhookdemo.callapi('https://httpbin.org/status/400', 'get', 'test'))
-    assert 400 == loginsightwebhookdemo.callapi('https://httpbin.org/status/400', 'get', 'test')[1]
+    assert 'method' in loginsightwebhookdemo.callapi('http://httpbin.org/anything', 'get')
+    assert 'authenticated' in loginsightwebhookdemo.callapi('http://httpbin.org/basic-auth/user/passwd', 'get', None, {"Cache-control": "no-cache"}, ('user', 'passwd'), False)
+    print(loginsightwebhookdemo.callapi('http://httpbin.org/status/400', 'get', 'test'))
+    assert 400 == loginsightwebhookdemo.callapi('http://httpbin.org/status/400', 'get', 'test')[1]
 
 
 def test_homepage():

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -198,12 +198,10 @@ def test_callapi():
         assert True
     else:
         assert False
-    assert 'google.j' in loginsightwebhookdemo.callapi('http://www.google.com', 'get')
-    assert 'google.j' in loginsightwebhookdemo.callapi('http://www.google.com', 'get', None, {"Cache-control": "no-cache"}, ('user', 'pass'), False)
-    if any('400' in code for code in loginsightwebhookdemo.callapi('http://www.google.com', 'get', 'test')):
-        assert True
-    else:
-        assert False
+    assert 'method' in loginsightwebhookdemo.callapi('https://httpbin.org/anything', 'get')
+    assert 'authenticated' in loginsightwebhookdemo.callapi('https://httpbin.org/basic-auth/user/passwd', 'get', None, {"Cache-control": "no-cache"}, ('user', 'passwd'), False)
+    print(loginsightwebhookdemo.callapi('https://httpbin.org/status/400', 'get', 'test'))
+    assert 400 == loginsightwebhookdemo.callapi('https://httpbin.org/status/400', 'get', 'test')[1]
 
 
 def test_homepage():


### PR DESCRIPTION
Fix flakey test that relied on static responses from
GET google.com. Replaced with requests against the
httpb.in endpoints, which respond in predictable ways.