### PR TITLE
Test in travis with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,23 @@ sudo: false
 language: python
 python:
     - "2.7_with_system_site_packages"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "3.7-dev"
+    - "nightly"
+    - "pypy"
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: 3.3
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7-dev
+    - python: nightly
+    - python: pypy
 install:
     - pip install -r test-requirements.txt
     - pip install coveralls


### PR DESCRIPTION
Python2 is EOL, which resulted in issue #72.

As a first step to ensuring python3 compatibility,
run all tests under python 3.3-3.7 in Travis but ignore failures.

Once all pass, the allow_failures list can be shortened.