### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Three installation methods exist. Please select the one you are most comfortable
 
 ::
 
-    tdnf install wget python2 python2-xml -y
+    tdnf install wget python2 python-xml -y
     wget https://bootstrap.pypa.io/get-pip.py
     python get-pip.py
     pip install virtualenv


### PR DESCRIPTION
Fix typo for Photon 2.0 instructions, it's python-xml not python2-xml.